### PR TITLE
Load environment variables from .env globally

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -656,6 +656,7 @@ async fn execute_command(args: &Args) -> (&'static str, Output) {
 
     // MEJORA: Cargar variables de entorno desde .env automáticamente para todos los comandos
     // Esto es especialmente útil para 'run' y 'test', pero no hace daño en otros.
+    // Usamos std::env::set_var para que afecte a todos los comandos futuros del proceso
     if let Ok(env_vars) = load_env_file(&args.project) {
         if !env_vars.is_empty() {
             println!(
@@ -663,7 +664,9 @@ async fn execute_command(args: &Args) -> (&'static str, Output) {
                 "ℹ".blue(),
                 env_vars.len()
             );
-            cmd.envs(env_vars);
+            for (key, value) in env_vars {
+                std::env::set_var(key, value);
+            }
         }
     }
 
@@ -2326,13 +2329,22 @@ fn load_env_file(
     let mut vars = std::collections::HashMap::new();
 
     for line in content.lines() {
-        let line = line.trim();
+        let mut line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
 
+        // Soporte para 'export KEY=VALUE'
+        if line.starts_with("export ") {
+            line = line.trim_start_matches("export ").trim();
+        }
+
         if let Some((key, value)) = line.split_once('=') {
             let key = key.trim().to_string();
+            if key.is_empty() {
+                continue;
+            }
+
             let value = value
                 .trim()
                 .trim_matches('"')


### PR DESCRIPTION
The changes ensure that environment variables defined in a `.env` file are automatically loaded and made available to all cargo commands executed by the TRAE CLI. This is achieved by setting the variables at the process level using `std::env::set_var`. Additionally, the `.env` parser was enhanced to support common conventions like the `export` keyword.

---
*PR created automatically by Jules for task [5059622168018665947](https://jules.google.com/task/5059622168018665947) started by @Rigohl*

## Summary by Sourcery

Load environment variables from .env at the process level so they apply to all subsequent TRAE CLI cargo commands.

New Features:
- Automatically load variables from a project .env file into the process environment for all executed cargo commands.
- Support parsing .env lines that use the `export KEY=VALUE` convention.

Enhancements:
- Ignore invalid .env entries with empty keys when parsing environment variables.