### PR TITLE
🔒 [security fix] Fix Path Traversal in Daemon and MCP commands

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -3,10 +3,11 @@
 #![doc = " Inicia el binario `trae-server` en segundo plano, con opción de silenciar"]
 #![doc = " stdout/stderr o redirigir a un archivo de log."]
 use crate::cli::TraeCli;
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::Args;
 use colored::Colorize;
 use std::fs::File;
+use std::path::Path;
 use std::process::Stdio;
 use tokio::process::Command;
 #[derive(Args, Debug)]
@@ -37,12 +38,22 @@ impl DaemonCommand {
             .cyan()
             .bold()
         );
+
         let mut cmd = Command::new(&self.binary);
         cmd.env("PORT", self.port.to_string());
         match (&self.log, self.quiet) {
-            (Some(path), _) => {
+            (Some(path_str), _) => {
+                let path = Path::new(path_str);
+
+                // Security check: Prevent path traversal
+                if path.is_absolute()
+                    || path.components().any(|c| matches!(c, std::path::Component::ParentDir))
+                {
+                    return Err(anyhow!("Ruta de log inválida: {}. No se permiten rutas absolutas o con '..'", path_str));
+                }
+
                 let log_file = File::create(path)
-                    .with_context(|| format!("No se pudo abrir log en {}", path))?;
+                    .with_context(|| format!("No se pudo abrir log en {}", path_str))?;
                 let stdout = Stdio::from(log_file.try_clone()?);
                 let stderr = Stdio::from(log_file);
                 cmd.stdout(stdout);

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -1,7 +1,7 @@
 #![doc = " # MCP Command"]
 #![doc = ""]
 #![doc = " Inicia y controla procesos MCP personalizados en background."]
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::{Args, Subcommand};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -88,6 +88,15 @@ impl McpCommand {
         cmd.arg("--port").arg(port.to_string());
         cmd.args(extra_args);
         if let Some(log_path) = &log {
+            // Security check: Prevent path traversal
+            if log_path.is_absolute()
+                || log_path
+                    .components()
+                    .any(|c| matches!(c, std::path::Component::ParentDir))
+            {
+                return Err(anyhow!("Ruta de log inválida: {}. No se permiten rutas absolutas o con '..'", log_path.display()));
+            }
+
             let file = fs::File::create(log_path)
                 .with_context(|| format!("No se pudo abrir log {}", log_path.display()))?;
             let stderr = file.try_clone()?;


### PR DESCRIPTION
🎯 **What:** Fixed a Path Traversal vulnerability in the `daemon` and `mcp` commands where user-provided log paths were used without validation.
⚠️ **Risk:** An attacker could specify a path like `../../etc/passwd` to overwrite sensitive system files or write files to unauthorized locations.
🛡️ **Solution:** Added validation logic using `std::path::Path::components()` to ensure provided paths are not absolute and do not contain any "parent directory" (`..`) components, restricting log files to the current directory or its subdirectories.

---
*PR created automatically by Jules for task [11461877551331453312](https://jules.google.com/task/11461877551331453312) started by @Rigohl*

## Summary by Sourcery

Bug Fixes:
- Reject absolute or parent-directory-containing log paths for daemon and MCP commands to eliminate a path traversal vulnerability.