### PR TITLE
🧹 remove unused TestPerformance struct

### DIFF
--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -203,16 +203,6 @@ impl TestCommand {
     #[doc = "Method documentation added by AI refactor"]
     fn analyze_test_performance(&self, _cli: &TraeCli) -> Result<PerformanceAnalysis> {
         Ok(PerformanceAnalysis {
-            slowest_tests: vec![TestPerformance {
-                name: "test_slow_example".to_string(),
-                duration: 5000.0,
-                category: "integration".to_string(),
-            }],
-            fastest_tests: vec![TestPerformance {
-                name: "test_fast_example".to_string(),
-                duration: 0.5,
-                category: "unit".to_string(),
-            }],
             test_distribution: HashMap::from([
                 ("unit".to_string(), 85),
                 ("integration".to_string(), 12),
@@ -282,18 +272,6 @@ impl TestCommand {
         }
         if let Some(perf) = perf {
             println!("\n{}", "🔍 ANÁLISIS DE PERFORMANCE".yellow().bold());
-            println!(
-                "{} Test más lento: {} ({:.1}ms)",
-                "🐌".red(),
-                perf.slowest_tests[0].name,
-                perf.slowest_tests[0].duration
-            );
-            println!(
-                "{} Test más rápido: {} ({:.1}ms)",
-                "🚀".green(),
-                perf.fastest_tests[0].name,
-                perf.fastest_tests[0].duration
-            );
             println!("\n{}", "📊 Distribución de Tests:".cyan());
             for (category, count) in &perf.test_distribution {
                 println!("  {category}: {count}");
@@ -414,18 +392,8 @@ struct BenchmarkResults {
     total_time: f64,
 }
 #[derive(Debug)]
-#[allow(dead_code)]
-#[doc = "Struct documentation added by AI refactor"]
-struct TestPerformance {
-    name: String,
-    duration: f64,
-    category: String,
-}
-#[derive(Debug)]
 #[doc = "Struct documentation added by AI refactor"]
 struct PerformanceAnalysis {
-    slowest_tests: Vec<TestPerformance>,
-    fastest_tests: Vec<TestPerformance>,
     test_distribution: HashMap<String, usize>,
     recommendations: Vec<String>,
 }


### PR DESCRIPTION
🎯 **What:** Removed the unused `TestPerformance` struct and its references in `src/commands/test.rs`.
💡 **Why:** The struct was marked with `#[allow(dead_code)]` and only contained hardcoded mock data. Removing it reduces clutter and clarifies that performance analysis is currently based on other metrics (like distribution and recommendations).
✅ **Verification:**
- Confirmed the struct and its field usages are completely removed from `src/commands/test.rs`.
- Code review confirmed the change is safe as the data was entirely mock/placeholder.
✨ **Result:** A cleaner codebase with less dead code and reduced reliance on placeholder data structures.

---
*PR created automatically by Jules for task [10427669883184409695](https://jules.google.com/task/10427669883184409695) started by @Rigohl*

## Summary by Sourcery

Remove unused test performance data structures and mock performance output from the test command.

Enhancements:
- Simplify performance analysis by relying only on test distribution and recommendations instead of mock slowest/fastest test data.

Chores:
- Delete the unused TestPerformance struct and associated fields/references from the PerformanceAnalysis flow.