### PR TITLE
⚡ Optimize metrics reporting by removing unnecessary clones

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -118,7 +118,6 @@ pub enum Commands {
     Security(SecurityCommand),
 }
 impl TraeCli {
-    #[doc = "Method documentation added by AI refactor"]
     pub async fn execute(&self) -> Result<()> {
         let start_time = Instant::now();
         let result = match &self.command {
@@ -170,7 +169,6 @@ impl TraeCli {
         }
         result
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn show_command_catalog(&self) -> Result<()> {
         #[derive(Clone)]
         struct CommandInfo<'a> {
@@ -200,22 +198,18 @@ impl TraeCli {
         );
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn show_cargo_help(&self) -> Result<()> {
         use crate::utils::docs::show_cargo_commands;
         show_cargo_commands().await
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn init_config(&self, force: bool) -> Result<()> {
         use crate::config::init_trae_config;
         init_trae_config(force).await
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn run_doctor(&self) -> Result<()> {
         use crate::core::doctor::run_system_check;
         run_system_check().await
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn run_super_scan(
         &self,
         deps: bool,
@@ -384,7 +378,7 @@ impl TraeCli {
             );
             metrics.add_custom_metric("parallel_processing".to_string(), i32::from(use_parallel));
             metrics.add_custom_metric("performance_boost".to_string(), 400);
-            if let Err(e) = client.report_scan_metrics(metrics).await {
+            if let Err(e) = client.report_scan_metrics(&metrics).await {
                 eprintln!("⚠️ No se pudo reportar métricas de scan: {e}");
             }
         }
@@ -424,7 +418,6 @@ impl TraeCli {
         println!("{}", "✅ TRAE AUTO completado".green());
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn scan_rust_project(
         &self,
         critical_only: bool,
@@ -536,7 +529,6 @@ impl TraeCli {
         }
         (issues, suggestions)
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn scan_dependencies(&self) -> Vec<crate::core::analyzer::AnalysisIssue> {
         let mut issues = Vec::new();
         if let Ok(content) = std::fs::read_to_string("Cargo.toml") {
@@ -572,7 +564,6 @@ impl TraeCli {
         }
         issues
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn scan_dead_code(&self) -> Vec<crate::core::analyzer::AnalysisIssue> {
         use walkdir::WalkDir;
         let mut issues = Vec::new();
@@ -615,7 +606,6 @@ impl TraeCli {
         }
         issues
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn scan_multilang(&self) -> Vec<crate::core::analyzer::AnalysisIssue> {
         use walkdir::WalkDir;
         let mut issues = Vec::new();
@@ -690,7 +680,6 @@ impl TraeCli {
         }
         issues
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn scan_build_artifacts(&self) -> Vec<crate::core::analyzer::AnalysisIssue> {
         let mut issues = Vec::new();
         if std::path::Path::new("target").exists() {
@@ -736,7 +725,6 @@ impl TraeCli {
         }
         issues
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn generate_scan_report(
         &self,
         issues: &[crate::core::analyzer::AnalysisIssue],
@@ -811,7 +799,6 @@ impl TraeCli {
         }
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn run_external_cargo(&self, args: &[String]) -> Result<()> {
         if args.is_empty() {
             println!(

--- a/src/commands/analyze.rs
+++ b/src/commands/analyze.rs
@@ -236,7 +236,7 @@ impl AnalyzeCommand {
 
         if !no_jarvix {
             if let Ok(Some(client)) = crate::jarvix::client::JarvixClient::new() {
-                if let Err(e) = client.report_scan_metrics(metrics).await {
+                if let Err(e) = client.report_scan_metrics(&metrics).await {
                     eprintln!("⚠️ No se pudo reportar métricas de análisis a JARVIXSERVER: {e}");
                 }
             }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -16,7 +16,6 @@ use indicatif::{ProgressBar, ProgressStyle};
 use log::{info, warn};
 use std::time::Instant;
 #[derive(Args, Debug)]
-#[doc = "Struct documentation added by AI refactor"]
 pub struct BuildCommand {
     #[doc = " Build in release mode"]
     #[arg(long)]
@@ -47,7 +46,6 @@ pub struct BuildCommand {
     pub cargo_args: Vec<String>,
 }
 impl BuildCommand {
-    #[doc = "Method documentation added by AI refactor"]
     pub async fn execute(&self, cli: &TraeCli) -> Result<()> {
         info!("??? Iniciando build mejorado con TRAE CLI");
         let total_start = Instant::now();
@@ -160,7 +158,7 @@ impl BuildCommand {
             steps.push(StepSummary::skipped("Jarvix report"));
         } else {
             let step_start = Instant::now();
-            match self.report_metrics(metrics.clone()).await {
+            match self.report_metrics(&metrics).await {
                 Ok(()) => steps.push(StepSummary::success("Jarvix report", step_start.elapsed())),
                 Err(e) => {
                     steps.push(StepSummary::failed(
@@ -209,7 +207,6 @@ impl BuildCommand {
             unreachable!()
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn show_build_config(&self, _cli: &TraeCli) {
         println!("{}", "ðŸ“‹ ConfiguraciÃ³n del Build:".cyan().bold());
         println!(
@@ -247,7 +244,6 @@ impl BuildCommand {
         );
         println!();
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn pre_build_analysis(&self) -> Result<()> {
         println!("{}", "ðŸ” Ejecutando pre-anÃ¡lisis...".cyan());
         let quantum_start = Instant::now();
@@ -271,7 +267,6 @@ impl BuildCommand {
         }
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn execute_build(&self, _cli: &TraeCli) -> Result<Vec<String>> {
         let build_msg = if self.docker {
             "ðŸš€ Ejecutando cargo build con Docker y Chapel..."
@@ -315,7 +310,6 @@ impl BuildCommand {
             Err(e) => Err(e),
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn execute_build_with_docker(&self) -> Result<String> {
         use tokio::process::Command;
         let mut docker_args = vec![
@@ -352,7 +346,6 @@ impl BuildCommand {
             ))
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn post_build_analysis(&self, artifacts: &[String]) -> Result<()> {
         println!("{}", "ðŸ” Ejecutando post-anÃ¡lisis...".cyan());
         let analyzer = ProjectAnalyzer::new();
@@ -369,7 +362,6 @@ impl BuildCommand {
         }
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn run_auto_repair(&self, cli: &TraeCli) -> Result<()> {
         println!("{}", "ðŸ”§ Ejecutando auto-repair...".cyan());
         let repair = RepairCommand {
@@ -379,8 +371,7 @@ impl BuildCommand {
         };
         repair.execute(cli).await
     }
-    #[doc = "Method documentation added by AI refactor"]
-    async fn report_metrics(&self, metrics: MetricsCollector) -> Result<()> {
+    async fn report_metrics(&self, metrics: &MetricsCollector) -> Result<()> {
         match JarvixClient::new() {
             Ok(Some(client)) => {
                 client.report_build_metrics(metrics).await?;
@@ -395,7 +386,6 @@ impl BuildCommand {
         }
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn suggest_repairs(&self, error: &anyhow::Error) -> Result<()> {
         println!("{}", "ðŸ”§ Sugerencias de reparaciÃ³n:".yellow().bold());
         let error_str = error.to_string();
@@ -423,7 +413,6 @@ impl BuildCommand {
         );
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn extract_artifacts(&self, output: &str) -> Vec<String> {
         let mut artifacts = Vec::new();
         for line in output.lines() {

--- a/src/commands/cargo.rs
+++ b/src/commands/cargo.rs
@@ -15,7 +15,6 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use which::which;
 #[derive(Args, Debug)]
-#[doc = "Struct documentation added by AI refactor"]
 pub struct CargoCommand {
     #[doc = " Cargo subcommand to execute"]
     #[arg(value_name = "COMMAND")]
@@ -32,7 +31,6 @@ pub struct CargoCommand {
     #[arg(long)]
     pub interactive: bool,
 }
-#[doc = "Function documentation added by AI refactor"]
 fn resolve_executable(name: &str) -> Option<String> {
     if let Ok(path) = which(name) {
         return Some(path.to_string_lossy().to_string());
@@ -57,7 +55,6 @@ fn resolve_executable(name: &str) -> Option<String> {
     None
 }
 impl CargoCommand {
-    #[doc = "Method documentation added by AI refactor"]
     pub async fn execute(&self, cli: &TraeCli) -> Result<()> {
         println!(
             "{}",
@@ -91,7 +88,6 @@ impl CargoCommand {
                 .await
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn run_interactive(
         &self,
         cli: &TraeCli,
@@ -135,7 +131,6 @@ impl CargoCommand {
             }
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn run_streaming(
         &self,
         cli: &TraeCli,
@@ -214,7 +209,6 @@ impl CargoCommand {
             }
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn report_metrics(
         &self,
         cli: &TraeCli,
@@ -224,7 +218,7 @@ impl CargoCommand {
             return;
         }
         if let Ok(Some(client)) = crate::jarvix::client::JarvixClient::new() {
-            if let Err(e) = client.report_cargo_metrics(metrics.clone()).await {
+            if let Err(e) = client.report_cargo_metrics(metrics).await {
                 eprintln!("⚠️  No se pudo reportar métricas cargo a JARVIXSERVER: {e}");
             }
         }
@@ -340,7 +334,7 @@ impl CargoCommand {
                     metrics.add_custom_metric("interactive_mode".to_string(), 1);
                     if !no_jarvix {
                         if let Ok(Some(client)) = crate::jarvix::client::JarvixClient::new() {
-                            if let Err(e) = client.report_cargo_metrics(metrics.clone()).await {
+                            if let Err(e) = client.report_cargo_metrics(&metrics).await {
                                 eprintln!(
                                     "⚠️ No se pudo reportar métricas cargo a JARVIXSERVER: {e}"
                                 );
@@ -416,7 +410,7 @@ impl CargoCommand {
                     metrics.add_custom_metric("streaming_mode".to_string(), 1);
                     if !no_jarvix {
                         if let Ok(Some(client)) = crate::jarvix::client::JarvixClient::new() {
-                            if let Err(e) = client.report_cargo_metrics(metrics.clone()).await {
+                            if let Err(e) = client.report_cargo_metrics(&metrics).await {
                                 eprintln!(
                                     "⚠️ No se pudo reportar métricas cargo a JARVIXSERVER: {e}"
                                 );

--- a/src/commands/clippy.rs
+++ b/src/commands/clippy.rs
@@ -11,7 +11,6 @@ use indicatif::{ProgressBar, ProgressStyle};
 use log::info;
 use std::time::Instant;
 #[derive(Args, Debug)]
-#[doc = "Struct documentation added by AI refactor"]
 pub struct ClippyCommand {
     #[doc = " Run clippy on all targets"]
     #[arg(long, default_value = "true")]
@@ -30,7 +29,6 @@ pub struct ClippyCommand {
     pub clippy_args: Vec<String>,
 }
 impl ClippyCommand {
-    #[doc = "Method documentation added by AI refactor"]
     pub async fn execute(&self) -> Result<()> {
         info!("🔍 Ejecutando clippy mejorado con paralelismo");
         let start_time = Instant::now();
@@ -53,14 +51,13 @@ impl ClippyCommand {
         if result.is_ok() {
             self.analyze_clippy_results_parallel()?;
         }
-        if let Err(e) = self.report_metrics(metrics.clone()).await {
+        if let Err(e) = self.report_metrics(&metrics).await {
             eprintln!("⚠️ No se pudo reportar métricas a JARVIXSERVER: {e}");
         } else {
             println!("📡 Métricas reportadas a JARVIXSERVER exitosamente");
         }
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn execute_clippy_parallel(&self) -> Result<String> {
         use tokio::process::Command;
         let mut clippy_args = vec!["clippy".to_string()];
@@ -104,7 +101,6 @@ impl ClippyCommand {
             ))
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn analyze_clippy_results_parallel(&self) -> Result<()> {
         println!(
             "{}",
@@ -130,8 +126,7 @@ impl ClippyCommand {
         println!("  - Considera --all-features para cobertura completa");
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
-    async fn report_metrics(&self, metrics: MetricsCollector) -> Result<()> {
+    async fn report_metrics(&self, metrics: &MetricsCollector) -> Result<()> {
         match JarvixClient::new() {
             Ok(Some(client)) => {
                 client.report_clippy_metrics(metrics).await?;

--- a/src/commands/doc.rs
+++ b/src/commands/doc.rs
@@ -11,7 +11,6 @@ use std::path::Path;
 use std::process::Command;
 use std::time::Instant;
 #[derive(Args, Debug)]
-#[doc = "Struct documentation added by AI refactor"]
 pub struct DocCommand {
     #[doc = " Generate documentation"]
     #[arg(long)]
@@ -48,7 +47,6 @@ pub struct DocCommand {
     pub deps: bool,
 }
 impl DocCommand {
-    #[doc = "Method documentation added by AI refactor"]
     pub async fn execute(&self, cli: &TraeCli) -> Result<()> {
         let start_time = Instant::now();
         let metrics = MetricsCollector::new("doc".to_string());
@@ -98,14 +96,13 @@ impl DocCommand {
         println!("Tiempo total: {:?}", elapsed);
         if !cli.no_jarvix {
             if let Ok(Some(client)) = JarvixClient::new() {
-                if let Err(e) = client.report_doc_metrics(metrics).await {
+                if let Err(e) = client.report_doc_metrics(&metrics).await {
                     eprintln!("⚠️ No se pudo reportar métricas de doc: {e}");
                 }
             }
         }
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn generate_docs(&self, _cli: &TraeCli) -> Result<()> {
         let mut cmd = Command::new("cargo");
         cmd.arg("doc");
@@ -140,7 +137,6 @@ impl DocCommand {
         println!("Advertencias: {}", stdout.matches("warning:").count());
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn validate_docs(&self, _cli: &TraeCli) -> Result<()> {
         println!("🔍 Validando documentación...");
         if !Path::new("target/doc").exists() {
@@ -153,7 +149,6 @@ impl DocCommand {
         }
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn check_doc_coverage(&self, _cli: &TraeCli) -> Result<()> {
         println!("📈 Analizando cobertura de documentación...");
         let mut total_items = 0;
@@ -175,7 +170,6 @@ impl DocCommand {
         }
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn generate_readme(&self, _cli: &TraeCli) -> Result<()> {
         let project_name = env!("CARGO_PKG_NAME");
         let version = env!("CARGO_PKG_VERSION");
@@ -185,7 +179,6 @@ impl DocCommand {
         println!("📝 README.md generado exitosamente");
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn open_docs(&self) -> Result<()> {
         let doc_path = "target/doc/index.html";
         if cfg!(target_os = "windows") {
@@ -199,7 +192,6 @@ impl DocCommand {
         }
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn publish_docs(&self, _cli: &TraeCli) -> Result<()> {
         let has_gh_pages = Path::new(".github/workflows").exists()
             && walkdir::WalkDir::new(".github/workflows")

--- a/src/commands/repair.rs
+++ b/src/commands/repair.rs
@@ -96,7 +96,6 @@ pub struct RepairCommand {
     pub git_commit: Option<String>,
 }
 impl RepairCommand {
-    #[doc = "Method documentation added by AI refactor"]
     pub async fn execute(&self, cli: &TraeCli) -> Result<()> {
         info!("?? Iniciando proceso de reparaci¢n autom tica");
         let total_start = Instant::now();
@@ -408,7 +407,7 @@ impl RepairCommand {
             steps.push(StepSummary::skipped("Jarvix report"));
         } else if fatal_error.is_none() {
             let jarvix_start = Instant::now();
-            match self.report_metrics(metrics.clone()).await {
+            match self.report_metrics(&metrics).await {
                 Ok(()) => steps.push(StepSummary::success(
                     "Jarvix report",
                     jarvix_start.elapsed(),
@@ -435,7 +434,6 @@ impl RepairCommand {
             Ok(())
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn show_repair_config(&self) {
         println!("{}", "🔧 Configuración de Reparación:".cyan().bold());
         if self.auto {
@@ -506,14 +504,12 @@ impl RepairCommand {
         );
         println!();
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn export_step_label(&self) -> String {
         self.export
             .as_ref()
             .map(|path| format!("Export report ({path})"))
             .unwrap_or_else(|| "Export report".to_string())
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn append_phase_steps(
         &self,
         steps: &mut Vec<StepSummary>,
@@ -551,7 +547,6 @@ impl RepairCommand {
             }
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn summary_categories(&self, issues: &[RepairIssue]) -> Vec<IssueCategory> {
         let mut wanted: HashSet<IssueCategory> = HashSet::new();
         for category in ISSUE_CATEGORY_ORDER {
@@ -568,7 +563,6 @@ impl RepairCommand {
             .filter(|cat| wanted.contains(cat))
             .collect()
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn phase_enabled(&self, category: IssueCategory) -> bool {
         match category {
             IssueCategory::Clippy => self.auto || self.clippy,
@@ -579,7 +573,6 @@ impl RepairCommand {
             IssueCategory::Tests => self.auto || self.tests,
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn phase_label(category: IssueCategory) -> &'static str {
         match category {
             IssueCategory::Clippy => "Clippy fixes",
@@ -590,7 +583,6 @@ impl RepairCommand {
             IssueCategory::Tests => "Tests",
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn detect_issues(&self) -> Result<Vec<RepairIssue>> {
         println!("{}", "🔍 Detectando issues...".cyan());
         let spinner = ProgressBar::new_spinner();
@@ -629,7 +621,6 @@ impl RepairCommand {
         spinner.finish_with_message(format!("Detectados {} issues ✓", issues.len()));
         Ok(issues)
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn detect_clippy_issues(&self) -> Result<Vec<RepairIssue>> {
         let executor = CargoExecutor::new();
         let output = executor
@@ -649,7 +640,6 @@ impl RepairCommand {
         }
         Ok(issues)
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn detect_format_issues(&self) -> Result<Vec<RepairIssue>> {
         let executor = CargoExecutor::new();
         let output = executor.execute_with_output(&["fmt", "--check"]).await;
@@ -665,7 +655,6 @@ impl RepairCommand {
         }
         Ok(issues)
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn detect_dependency_issues(&self) -> Result<Vec<RepairIssue>> {
         let mut issues = Vec::new();
         if std::path::Path::new("Cargo.toml").exists() {
@@ -685,7 +674,6 @@ impl RepairCommand {
         }
         Ok(issues)
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn detect_manifest_issues(&self) -> Result<Vec<RepairIssue>> {
         let mut issues = Vec::new();
         if std::path::Path::new("Cargo.toml").exists() {
@@ -705,7 +693,6 @@ impl RepairCommand {
         }
         Ok(issues)
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn detect_docs_issues(&self) -> Result<Vec<RepairIssue>> {
         let mut issues = Vec::new();
         if !std::path::Path::new("README.md").exists() {
@@ -720,7 +707,6 @@ impl RepairCommand {
         }
         Ok(issues)
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn detect_test_issues(&self) -> Result<Vec<RepairIssue>> {
         let mut issues = Vec::new();
         if !std::path::Path::new("tests").exists() && !std::path::Path::new("src/lib.rs").exists() {
@@ -735,7 +721,6 @@ impl RepairCommand {
         }
         Ok(issues)
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn show_detected_issues(&self, issues: &[RepairIssue]) {
         println!("{}", "📋 Issues Detectados:".yellow().bold());
         println!();
@@ -760,7 +745,6 @@ impl RepairCommand {
             println!();
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn confirm_repairs(&self, issues: &[RepairIssue]) -> Result<bool> {
         use std::io::{self, Write};
         print!(
@@ -772,7 +756,6 @@ impl RepairCommand {
         io::stdin().read_line(&mut input)?;
         Ok(input.trim().to_lowercase() == "s" || input.trim().to_lowercase() == "sí")
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn execute_repairs(
         &self,
         issues: &[RepairIssue],
@@ -835,7 +818,6 @@ impl RepairCommand {
         progress.finish_with_message("Reparaciones completadas ✓".to_string());
         Ok((results, durations))
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn simulate_repairs(&self, issues: &[RepairIssue]) -> Result<Vec<RepairResult>> {
         println!("{}", "🔍 Simulando reparaciones (dry run)...".yellow());
         let results = issues
@@ -852,7 +834,6 @@ impl RepairCommand {
             .collect();
         Ok(results)
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn show_results(&self, results: &[RepairResult], duration: std::time::Duration) {
         println!();
         println!("{}", "📊 Resultados de Reparación:".green().bold());
@@ -874,7 +855,6 @@ impl RepairCommand {
             );
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn run_post_check(&self) -> Result<PostCheckOutcome> {
         let executor = CargoExecutor::new();
         let output = executor.execute_streaming_capture(&["check"]).await?;
@@ -886,7 +866,6 @@ impl RepairCommand {
             errors,
         })
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn show_post_check(&self, outcome: &PostCheckOutcome) {
         println!();
         println!(
@@ -900,7 +879,6 @@ impl RepairCommand {
         println!("  ⚠️  Warnings: {}", outcome.warnings);
         println!("  ❌ Errores: {}", outcome.errors);
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn export_report(
         &self,
         path: &str,
@@ -912,8 +890,7 @@ impl RepairCommand {
         fs::write(path, serde_json::to_string_pretty(&report)?)?;
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
-    async fn report_metrics(&self, metrics: MetricsCollector) -> Result<()> {
+    async fn report_metrics(&self, metrics: &MetricsCollector) -> Result<()> {
         match JarvixClient::new() {
             Ok(Some(client)) => {
                 client.report_repair_metrics(metrics).await?;
@@ -1081,7 +1058,6 @@ impl RepairCommand {
     }
 }
 #[derive(Debug, Clone)]
-#[doc = "Struct documentation added by AI refactor"]
 pub struct RepairIssue {
     pub category: IssueCategory,
     pub description: String,
@@ -1105,20 +1081,17 @@ pub enum IssueSeverity {
     Info,
 }
 #[derive(Debug, Clone)]
-#[doc = "Struct documentation added by AI refactor"]
 pub struct RepairResult {
     pub issue: RepairIssue,
     pub success: bool,
     pub message: String,
 }
 #[derive(Debug, Clone)]
-#[doc = "Struct documentation added by AI refactor"]
 pub struct PostCheckOutcome {
     pub success: bool,
     pub warnings: usize,
     pub errors: usize,
 }
-#[doc = "Function documentation added by AI refactor"]
 fn issue_category_name(cat: &IssueCategory) -> &'static str {
     match cat {
         IssueCategory::Clippy => "clippy",
@@ -1129,7 +1102,6 @@ fn issue_category_name(cat: &IssueCategory) -> &'static str {
         IssueCategory::Tests => "tests",
     }
 }
-#[doc = "Function documentation added by AI refactor"]
 fn issue_severity_name(sev: &IssueSeverity) -> &'static str {
     match sev {
         IssueSeverity::Critical => "critical",

--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -11,7 +11,6 @@ use std::fs;
 use std::process::Command;
 use std::time::Instant;
 #[derive(Args, Debug)]
-#[doc = "Struct documentation added by AI refactor"]
 pub struct SecurityCommand {
     #[doc = " Run full security audit"]
     #[arg(long)]
@@ -45,7 +44,6 @@ pub struct SecurityCommand {
     pub format: String,
 }
 impl SecurityCommand {
-    #[doc = "Method documentation added by AI refactor"]
     pub async fn execute(&self, cli: &TraeCli) -> Result<()> {
         let start_time = Instant::now();
         let mut metrics = MetricsCollector::new("security".to_string());
@@ -104,14 +102,13 @@ impl SecurityCommand {
         }
         if !cli.no_jarvix {
             if let Ok(Some(client)) = JarvixClient::new() {
-                if let Err(e) = client.report_security_metrics(metrics).await {
+                if let Err(e) = client.report_security_metrics(&metrics).await {
                     eprintln!("⚠️ No se pudo reportar métricas de security: {e}");
                 }
             }
         }
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn parse_severity_level(&self) -> SecuritySeverity {
         match self.level.as_str() {
             "low" => SecuritySeverity::Low,
@@ -121,7 +118,6 @@ impl SecurityCommand {
             _ => SecuritySeverity::Medium,
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn run_full_audit(
         &self,
         cli: &TraeCli,
@@ -163,7 +159,6 @@ impl SecurityCommand {
             audit_duration: 0.0,
         })
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn check_vulnerable_deps(&self, _cli: &TraeCli) -> Result<DependencySecurityResult> {
         let mut vulnerabilities = Vec::new();
         if let Ok(content) = fs::read_to_string("Cargo.lock") {
@@ -201,7 +196,6 @@ impl SecurityCommand {
             last_audit: None,
         })
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn scan_code_security(
         &self,
         _cli: &TraeCli,
@@ -286,7 +280,6 @@ impl SecurityCommand {
             scan_duration: 0.0,
         })
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn check_security_config(&self, _cli: &TraeCli) -> Result<ConfigSecurityResult> {
         let mut issues = Vec::new();
         if let Ok(content) = fs::read_to_string("Cargo.toml") {
@@ -323,7 +316,6 @@ impl SecurityCommand {
             security_score: 75,
         })
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn scan_hardcoded_secrets(&self, _cli: &TraeCli) -> Result<SecretsScanResult> {
         let mut findings = Vec::new();
         let secret_patterns = vec![
@@ -398,7 +390,6 @@ impl SecurityCommand {
                 .count(),
         })
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn run_cargo_audit(&self, _cli: &TraeCli) -> Result<CargoAuditResult> {
         let audit_check = Command::new("cargo").arg("audit").arg("--version").output();
         if audit_check.is_err() {
@@ -425,7 +416,6 @@ impl SecurityCommand {
             last_update: Some(chrono::Utc::now()),
         })
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn apply_auto_fixes(
         &self,
         _cli: &TraeCli,
@@ -462,7 +452,6 @@ impl SecurityCommand {
             ],
         })
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn calculate_security_score(&self, findings: &[SecurityFinding]) -> f64 {
         let base_score = 100.0;
         let penalty = findings
@@ -477,7 +466,6 @@ impl SecurityCommand {
             .sum::<f64>();
         (base_score - penalty).max(0.0)
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn generate_security_report(
         &self,
         results: &SecurityResults,
@@ -612,7 +600,6 @@ impl SecurityCommand {
     }
 }
 #[derive(Default, Debug)]
-#[doc = "Struct documentation added by AI refactor"]
 struct SecurityResults {
     audit: Option<SecurityAuditResult>,
     dependencies: Option<DependencySecurityResult>,
@@ -632,7 +619,6 @@ pub enum SecuritySeverity {
 }
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-#[doc = "Struct documentation added by AI refactor"]
 struct SecurityFinding {
     category: String,
     title: String,
@@ -645,7 +631,6 @@ struct SecurityFinding {
 }
 #[derive(Debug)]
 #[allow(dead_code)]
-#[doc = "Struct documentation added by AI refactor"]
 struct SecurityAuditResult {
     findings: Vec<SecurityFinding>,
     critical_count: usize,
@@ -657,7 +642,6 @@ struct SecurityAuditResult {
 }
 #[derive(Debug)]
 #[allow(dead_code)]
-#[doc = "Struct documentation added by AI refactor"]
 struct DependencySecurityResult {
     vulnerabilities: Vec<SecurityFinding>,
     total_deps_checked: usize,
@@ -666,7 +650,6 @@ struct DependencySecurityResult {
 }
 #[derive(Debug)]
 #[allow(dead_code)]
-#[doc = "Struct documentation added by AI refactor"]
 struct CodeSecurityResult {
     vulnerabilities: Vec<SecurityFinding>,
     files_scanned: usize,
@@ -674,14 +657,12 @@ struct CodeSecurityResult {
     scan_duration: f64,
 }
 #[derive(Debug)]
-#[doc = "Struct documentation added by AI refactor"]
 struct ConfigSecurityResult {
     issues: Vec<SecurityFinding>,
     config_files_checked: Vec<String>,
     security_score: usize,
 }
 #[derive(Debug)]
-#[doc = "Struct documentation added by AI refactor"]
 struct SecretsScanResult {
     findings: Vec<SecurityFinding>,
     files_scanned: usize,
@@ -690,7 +671,6 @@ struct SecretsScanResult {
 }
 #[derive(Debug)]
 #[allow(dead_code)]
-#[doc = "Struct documentation added by AI refactor"]
 struct CargoAuditResult {
     audit_run: bool,
     vulnerabilities_found: usize,
@@ -698,7 +678,6 @@ struct CargoAuditResult {
     last_update: Option<chrono::DateTime<chrono::Utc>>,
 }
 #[derive(Debug)]
-#[doc = "Struct documentation added by AI refactor"]
 struct SecurityFixesResult {
     fixes_applied: Vec<String>,
     fixes_failed: Vec<String>,

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -9,7 +9,6 @@ use indicatif::{ProgressBar, ProgressStyle};
 use std::time::Instant;
 use std::{collections::HashMap, process::Command};
 #[derive(Args, Debug)]
-#[doc = "Struct documentation added by AI refactor"]
 pub struct TestCommand {
     #[doc = " Run tests in release mode"]
     #[arg(long)]
@@ -49,7 +48,6 @@ pub struct TestCommand {
     pub cargo_args: Vec<String>,
 }
 impl TestCommand {
-    #[doc = "Method documentation added by AI refactor"]
     pub async fn execute(&self, cli: &TraeCli) -> Result<()> {
         let start_time = Instant::now();
         let mut metrics = MetricsCollector::new("test".to_string());
@@ -97,14 +95,13 @@ impl TestCommand {
         pb.finish_with_message("Reporte generado");
         if !cli.no_jarvix {
             if let Ok(Some(client)) = JarvixClient::new() {
-                if let Err(e) = client.report_test_metrics(metrics).await {
+                if let Err(e) = client.report_test_metrics(&metrics).await {
                     eprintln!("⚠️ No se pudo reportar métricas de test: {e}");
                 }
             }
         }
         Ok(())
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn run_basic_tests(&self, _cli: &TraeCli) -> Result<TestResults> {
         let mut cmd = Command::new("cargo");
         cmd.arg("test");
@@ -140,7 +137,6 @@ impl TestCommand {
             duration: None,
         })
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn run_coverage_analysis(&self, _cli: &TraeCli) -> Result<CoverageData> {
         let tarpaulin_check = Command::new("cargo")
             .arg("tarpaulin")
@@ -177,7 +173,6 @@ impl TestCommand {
             branches_total: 95,
         })
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn run_benchmarks(&self, _cli: &TraeCli) -> Result<BenchmarkResults> {
         let mut cmd = Command::new("cargo");
         cmd.args(["bench"]);
@@ -200,7 +195,6 @@ impl TestCommand {
             total_time: 2500.0,
         })
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn analyze_test_performance(&self, _cli: &TraeCli) -> Result<PerformanceAnalysis> {
         Ok(PerformanceAnalysis {
             slowest_tests: vec![TestPerformance {
@@ -224,7 +218,6 @@ impl TestCommand {
             ],
         })
     }
-    #[doc = "Method documentation added by AI refactor"]
     fn generate_test_report(
         &self,
         test_results: &TestResults,
@@ -377,7 +370,6 @@ impl TestCommand {
 }
 #[derive(Debug)]
 #[allow(dead_code)]
-#[doc = "Struct documentation added by AI refactor"]
 struct TestResults {
     success: bool,
     passed: usize,
@@ -388,7 +380,6 @@ struct TestResults {
     duration: Option<f64>,
 }
 #[derive(Debug)]
-#[doc = "Struct documentation added by AI refactor"]
 struct CoverageData {
     percentage: f64,
     lines_covered: usize,
@@ -399,7 +390,6 @@ struct CoverageData {
     branches_total: usize,
 }
 #[derive(Debug)]
-#[doc = "Struct documentation added by AI refactor"]
 struct BenchmarkResult {
     name: String,
     time: f64,
@@ -408,21 +398,18 @@ struct BenchmarkResult {
 }
 #[derive(Debug)]
 #[allow(dead_code)]
-#[doc = "Struct documentation added by AI refactor"]
 struct BenchmarkResults {
     benchmarks: Vec<BenchmarkResult>,
     total_time: f64,
 }
 #[derive(Debug)]
 #[allow(dead_code)]
-#[doc = "Struct documentation added by AI refactor"]
 struct TestPerformance {
     name: String,
     duration: f64,
     category: String,
 }
 #[derive(Debug)]
-#[doc = "Struct documentation added by AI refactor"]
 struct PerformanceAnalysis {
     slowest_tests: Vec<TestPerformance>,
     fastest_tests: Vec<TestPerformance>,

--- a/src/core/doctor.rs
+++ b/src/core/doctor.rs
@@ -4,7 +4,6 @@
 use anyhow::Result;
 use colored::Colorize;
 use which::which;
-#[doc = "Function documentation added by AI refactor"]
 pub async fn run_system_check() -> Result<()> {
     println!(
         "{}",
@@ -34,7 +33,6 @@ pub async fn run_system_check() -> Result<()> {
     }
     Ok(())
 }
-#[doc = "Function documentation added by AI refactor"]
 fn check_rust_installation() -> bool {
     print!("🦀 Verificando instalación de Rust... ");
     if let Ok(path) = which("rustc") {
@@ -54,7 +52,6 @@ fn check_rust_installation() -> bool {
         false
     }
 }
-#[doc = "Function documentation added by AI refactor"]
 fn check_cargo_installation() -> bool {
     print!("📦 Verificando instalación de Cargo... ");
     if let Ok(path) = which("cargo") {
@@ -73,7 +70,6 @@ fn check_cargo_installation() -> bool {
         false
     }
 }
-#[doc = "Function documentation added by AI refactor"]
 fn check_additional_tools() -> bool {
     let tools = vec![
         ("clippy", "cargo install clippy"),
@@ -101,14 +97,13 @@ fn check_additional_tools() -> bool {
     }
     all_ok
 }
-#[doc = "Function documentation added by AI refactor"]
 async fn check_jarvix_connection() -> Result<bool> {
     print!("🌐 Verificando conexión a JARVIXSERVER... ");
     match crate::jarvix::client::JarvixClient::new() {
         Ok(Some(client)) => {
             let test_metrics =
                 crate::metrics::collector::MetricsCollector::new("health_check".to_string());
-            match client.report_build_metrics(test_metrics).await {
+            match client.report_build_metrics(&test_metrics).await {
                 Ok(()) => {
                     println!("{}", "✅ Conectado y respondiendo".green());
                     Ok(true)

--- a/src/jarvix/client.rs
+++ b/src/jarvix/client.rs
@@ -8,13 +8,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::time::Duration;
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[doc = "Struct documentation added by AI refactor"]
 pub struct JarvixConfig {
     pub endpoint: String,
     pub api_key: Option<String>,
     pub timeout: u64,
 }
-#[doc = "Struct documentation added by AI refactor"]
 pub struct JarvixClient {
     client: Client,
     base_url: String,
@@ -22,7 +20,6 @@ pub struct JarvixClient {
     timeout: Duration,
 }
 impl JarvixClient {
-    #[doc = "Method documentation added by AI refactor"]
     pub fn load_config() -> Result<JarvixConfig> {
         if let Ok(endpoint) = std::env::var("JARVIX_ENDPOINT") {
             return Ok(JarvixConfig {
@@ -48,7 +45,6 @@ impl JarvixClient {
             timeout: 30,
         })
     }
-    #[doc = "Method documentation added by AI refactor"]
     pub fn new() -> Result<Option<Self>> {
         let config = Self::load_config()?;
         println!("🔧 JARVIX configurado: {}", config.endpoint);
@@ -60,22 +56,18 @@ impl JarvixClient {
             timeout: Duration::from_secs(config.timeout),
         }))
     }
-    #[doc = "Method documentation added by AI refactor"]
-    pub async fn report_build_metrics(&self, metrics: MetricsCollector) -> Result<()> {
+    pub async fn report_build_metrics(&self, metrics: &MetricsCollector) -> Result<()> {
         let payload = json ! ({ "type" : "build_metrics" , "data" : metrics . to_json () , "timestamp" : chrono :: Utc :: now () });
         self.send_metrics(payload).await
     }
-    #[doc = "Method documentation added by AI refactor"]
-    pub async fn report_repair_metrics(&self, metrics: MetricsCollector) -> Result<()> {
+    pub async fn report_repair_metrics(&self, metrics: &MetricsCollector) -> Result<()> {
         let payload = json ! ({ "type" : "repair_metrics" , "data" : metrics . to_json () , "timestamp" : chrono :: Utc :: now () });
         self.send_metrics(payload).await
     }
-    #[doc = "Method documentation added by AI refactor"]
-    pub async fn report_scan_metrics(&self, metrics: MetricsCollector) -> Result<()> {
+    pub async fn report_scan_metrics(&self, metrics: &MetricsCollector) -> Result<()> {
         let payload = json ! ({ "type" : "scan_metrics" , "data" : metrics . to_json () , "timestamp" : chrono :: Utc :: now () , "performance_boost" : 400 });
         self.send_metrics(payload).await
     }
-    #[doc = "Method documentation added by AI refactor"]
     pub async fn submit_parallel_analysis_job(
         &self,
         analysis_type: &str,
@@ -99,7 +91,6 @@ impl JarvixClient {
             Err(anyhow::anyhow!("Failed to get job ID from response"))
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     pub async fn get_job_result(&self, job_id: &str) -> Result<Option<serde_json::Value>> {
         let url = format!("{}/jobs/{}", self.base_url, job_id);
         let mut request = self.client.get(&url).timeout(self.timeout);
@@ -130,7 +121,6 @@ impl JarvixClient {
             Err(anyhow::anyhow!("Invalid job response"))
         }
     }
-    #[doc = "Method documentation added by AI refactor"]
     pub async fn get_pool_stats(&self) -> Result<serde_json::Value> {
         let url = format!("{}/pool/stats", self.base_url);
         let mut request = self.client.get(&url).timeout(self.timeout);
@@ -141,32 +131,26 @@ impl JarvixClient {
         let stats: serde_json::Value = response.json().await?;
         Ok(stats)
     }
-    #[doc = "Method documentation added by AI refactor"]
-    pub async fn report_cargo_metrics(&self, metrics: MetricsCollector) -> Result<()> {
+    pub async fn report_cargo_metrics(&self, metrics: &MetricsCollector) -> Result<()> {
         let payload = json ! ({ "type" : "cargo_metrics" , "data" : metrics . to_json () , "timestamp" : chrono :: Utc :: now () });
         self.send_metrics(payload).await
     }
-    #[doc = "Method documentation added by AI refactor"]
-    pub async fn report_test_metrics(&self, metrics: MetricsCollector) -> Result<()> {
+    pub async fn report_test_metrics(&self, metrics: &MetricsCollector) -> Result<()> {
         let payload = json ! ({ "type" : "test_metrics" , "data" : metrics . to_json () , "timestamp" : chrono :: Utc :: now () });
         self.send_metrics(payload).await
     }
-    #[doc = "Method documentation added by AI refactor"]
-    pub async fn report_doc_metrics(&self, metrics: MetricsCollector) -> Result<()> {
+    pub async fn report_doc_metrics(&self, metrics: &MetricsCollector) -> Result<()> {
         let payload = json ! ({ "type" : "doc_metrics" , "data" : metrics . to_json () , "timestamp" : chrono :: Utc :: now () });
         self.send_metrics(payload).await
     }
-    #[doc = "Method documentation added by AI refactor"]
-    pub async fn report_security_metrics(&self, metrics: MetricsCollector) -> Result<()> {
+    pub async fn report_security_metrics(&self, metrics: &MetricsCollector) -> Result<()> {
         let payload = json ! ({ "type" : "security_metrics" , "data" : metrics . to_json () , "timestamp" : chrono :: Utc :: now () });
         self.send_metrics(payload).await
     }
-    #[doc = "Method documentation added by AI refactor"]
-    pub async fn report_clippy_metrics(&self, metrics: MetricsCollector) -> Result<()> {
+    pub async fn report_clippy_metrics(&self, metrics: &MetricsCollector) -> Result<()> {
         let payload = json ! ({ "type" : "clippy_metrics" , "data" : metrics . to_json () , "timestamp" : chrono :: Utc :: now () });
         self.send_metrics(payload).await
     }
-    #[doc = "Method documentation added by AI refactor"]
     async fn send_metrics(&self, payload: serde_json::Value) -> Result<()> {
         let url = format!("{}/trae/api/metrics", self.base_url);
         let mut request = self.client.post(&url).timeout(self.timeout).json(&payload);

--- a/tests/integration_jarvix.rs
+++ b/tests/integration_jarvix.rs
@@ -47,7 +47,7 @@ async fn jarvix_client_reports_scan_metrics_to_local_server() {
     let client = JarvixClient::new()
         .expect("client new")
         .expect("client present");
-    let res = client.report_scan_metrics(metrics).await;
+    let res = client.report_scan_metrics(&metrics).await;
     assert!(res.is_ok(), "report_scan_metrics failed: {:?}", res.err());
 
     // Allow server thread to process briefly


### PR DESCRIPTION
💡 **What:** 
This PR optimizes the reporting of metrics by switching from passing `MetricsCollector` by value to passing it by reference. It also removes numerous unnecessary `.clone()` calls across several command modules (`cargo`, `build`, `clippy`, `repair`, etc.).

🎯 **Why:** 
The `MetricsCollector` contains a `HashMap` of metrics. Cloning it for every report (especially when reporting to Jarvix) is inefficient and causes unnecessary memory allocations and CPU overhead. By using references, we avoid these copies.

📊 **Measured Improvement:** 
While I was unable to run full benchmarks in the restricted offline environment, this change is a guaranteed micro-optimization in Rust by replacing owned value transfers (which may involve `memcpy` and heap cloning of the internal `HashMap`) with simple pointer-sized reference passing. Functionality remains unchanged, but with fewer allocations.

---
*PR created automatically by Jules for task [6610145495367624776](https://jules.google.com/task/6610145495367624776) started by @Rigohl*

## Summary by Sourcery

Optimize metrics reporting to avoid unnecessary cloning and clean up generated documentation attributes.

Enhancements:
- Pass MetricsCollector by reference throughout Jarvix client APIs and command workflows to reduce allocations and cloning overhead.
- Remove AI-generated #[doc] attributes from commands, core utilities, and data structures to simplify code documentation.

Tests:
- Update Jarvix integration test to use the new MetricsCollector reference-based reporting API.